### PR TITLE
FIX postgres startup delay

### DIFF
--- a/scripts/start_lisk
+++ b/scripts/start_lisk
@@ -47,5 +47,6 @@ populate_database() {
 }
 
 sudo service postgresql start
+sleep 60 # give postgres a chance to start
 populate_database
 node app.js


### PR DESCRIPTION
For some reason, when I try to start a container from this image,
postgres will be extremely slow to start, causing further commands from
`start_lisk` to generate error:

```
$ docker run -p 0.0.0.0:7000:7000 lisk/testnet
 * Starting PostgreSQL 9.5 database server
   ...done.
psql: FATAL:  the database system is starting up
log 2016-06-26 12:09:43 error error: FATAL:  the database system is starting up
FATAL:  the database system is starting up
log 2016-06-26 12:09:43 error connection: {"host":"localhost","port":5432,"database":"lisk_test","password":"########","poolSize":20,"poolIdleTimeout":30000,"reapIntervalMillis":1000,"logEvents":["error"]}
fatal 2016-06-26 12:09:43 [Error: FATAL:  the database system is starting up
FATAL:  the database system is starting up
]
info 2016-06-26 12:09:43 Lisk started: 0.0.0.0:7000
```

After that, the lisk server is up, but will just display an error when
trying to load it in browser on port 7000.

I managed to fix that by adding a delay after asking postgres to start.
