### PR TITLE
Enable public API by default - Closes #13

### DIFF
--- a/Dockerfile.main
+++ b/Dockerfile.main
@@ -37,6 +37,7 @@ RUN mv -f lisk-source lisk
 RUN rm lisk-source.tar.gz
 WORKDIR lisk
 RUN npm install --production
+RUN sed -i 's/"public": false,/"public": true,/g' config.json
 
 # Install Lisk Node
 RUN wget https://downloads.lisk.io/lisk-node/lisk-node-Linux-x86_64.tar.gz -O lisk-node-Linux-x86_64.tar.gz

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -37,6 +37,7 @@ RUN mv -f lisk-source lisk
 RUN rm lisk-source.tar.gz
 WORKDIR lisk
 RUN npm install --production
+RUN sed -i 's/"public": false,/"public": true,/g' config.json
 
 # Install Lisk Node
 RUN wget https://downloads.lisk.io/lisk-node/lisk-node-Linux-x86_64.tar.gz -O lisk-node-Linux-x86_64.tar.gz


### PR DESCRIPTION
Docker runs as a resident VM on PCs in most cases. Therefore
we should offer public API as open by default since the risk
of the machine getting attacked is minimal as the machine should
be firewalled and safe. This saves many users the hurdle of
changing the config themselves as well.

Closes #13 