### PR TITLE
Xenial and mount Host time in containers

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,11 +1,11 @@
-FROM ubuntu:trusty
+FROM ubuntu:xenial
 MAINTAINER LiskHQ
 LABEL description="Lisk Docker Image - Local Testnet" version="1.3.4"
 
 # Install Essentials
 WORKDIR /root
 RUN apt-get update
-RUN apt-get install -y autoconf automake build-essential curl git gzip libtool nano python wget tar jq
+RUN apt-get install -y autoconf automake build-essential curl git gzip libtool nano python wget tar jq sudo
 
 # Install Node.js and tools
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -

--- a/Dockerfile.main
+++ b/Dockerfile.main
@@ -1,11 +1,11 @@
-FROM ubuntu:trusty
+FROM ubuntu:xenial
 MAINTAINER LiskHQ
 LABEL description="Lisk Docker Image - Mainnet" version="1.3.4"
 
 # Install Essentials
 WORKDIR /root
 RUN apt-get update
-RUN apt-get install -y autoconf automake build-essential curl git gzip libtool nano python wget tar jq
+RUN apt-get install -y autoconf automake build-essential curl git gzip libtool nano python wget tar jq sudo
 
 # Install Node.js
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,11 +1,11 @@
-FROM ubuntu:trusty
+FROM ubuntu:xenial
 MAINTAINER LiskHQ
 LABEL description="Lisk Docker Image - Testnet" version="1.3.4"
 
 # Install Essentials
 WORKDIR /root
 RUN apt-get update
-RUN apt-get install -y autoconf automake build-essential curl git gzip libtool nano python wget tar jq
+RUN apt-get install -y autoconf automake build-essential curl git gzip libtool nano python wget tar jq sudo
 
 # Install Node.js
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Passing the following environment variables to the container using `-e VARX=VALX
 - DATABASE_USER
 - DATABASE_PASSWORD
 
-#### 9. Using Docker Compose
+#### 10. Using Docker Compose
 
 Example:
 

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -13,6 +13,8 @@ services:
       - LOG_LEVEL=info
     links:
       - PostgreSQL:postgresql
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
   PostgreSQL:
     restart: always
     image: postgres:9.6.3

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -21,3 +21,5 @@ services:
     environment:
       - POSTGRES_USER=lisk_local
       - POSTGRES_PASSWORD=password
+    volumes:
+      - /etc/localtime:/etc/localtime:ro

--- a/docker-compose-main.yml
+++ b/docker-compose-main.yml
@@ -21,3 +21,5 @@ services:
     environment:
       - POSTGRES_USER=lisk_main
       - POSTGRES_PASSWORD=password
+    volumes:
+      - /etc/localtime:/etc/localtime:ro

--- a/docker-compose-main.yml
+++ b/docker-compose-main.yml
@@ -13,6 +13,8 @@ services:
       - LOG_LEVEL=info
     links:
       - PostgreSQL:postgresql
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
   PostgreSQL:
     restart: always
     image: postgres:9.6.3

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -13,6 +13,8 @@ services:
       - LOG_LEVEL=info
     links:
       - PostgreSQL:postgresql
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
   PostgreSQL:
     restart: always
     image: postgres:9.6.3

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -21,3 +21,5 @@ services:
     environment:
       - POSTGRES_USER=lisk_test
       - POSTGRES_PASSWORD=password
+    volumes:
+      - /etc/localtime:/etc/localtime:ro


### PR DESCRIPTION
- Upgraded base image to Ubuntu Xenial
- Mount Docker host time for the containers in the compose files

In order to really avoid time issue you must have NTP running on the docker host. On Windows and Mac this is the Linux VM that is running docker. It often happens that the VM time drifts.

Closes #19 
Closes #20 