### PR TITLE
Removed the need for the _check databases - closes #32

### DIFF
--- a/scripts/start_lisk
+++ b/scripts/start_lisk
@@ -53,22 +53,22 @@ populate_database() {
 
   if [ "$DATABASE_HOST" == "localhost" ]
   then
-    echo "Looking for peers table"
-    psql -qd "$DATABASE_NAME" -c "select count(*) from peers;" &> /dev/null
+    echo "Looking for blocks table"
+    psql -qd "$DATABASE_NAME" -c "select count(*) from blocks;" &> /dev/null
     if [ $? == 1 ]; then
       download_blockchain
       restore_blockchain
       else
-      echo "Found peers table"
+      echo "Found blocks table"
     fi
   else
-    echo "Looking for peers table"
-    psql -h "$DATABASE_HOST" -U "$DATABASE_USER" -d "$DATABASE_NAME" -w -c "select count(*) from peers;" &> /dev/null
+    echo "Looking for blocks table"
+    psql -h "$DATABASE_HOST" -U "$DATABASE_USER" -d "$DATABASE_NAME" -w -c "select count(*) from blocks;" &> /dev/null
     if [ $? == 1 ]; then
       download_blockchain
       restore_blockchain
       else
-      echo "Found peers table"
+      echo "Found blocks table"
     fi
   fi
 }

--- a/scripts/start_lisk
+++ b/scripts/start_lisk
@@ -54,7 +54,7 @@ populate_database() {
   if [ "$DATABASE_HOST" == "localhost" ]
   then
     echo "Looking for blocks table"
-    psql -qd "$DATABASE_NAME" -c "select count(*) from blocks;" &> /dev/null
+    psql -qd "$DATABASE_NAME" -c "select * from blocks limit 1;" &> /dev/null
     if [ $? == 1 ]; then
       download_blockchain
       restore_blockchain
@@ -63,7 +63,7 @@ populate_database() {
     fi
   else
     echo "Looking for blocks table"
-    psql -h "$DATABASE_HOST" -U "$DATABASE_USER" -d "$DATABASE_NAME" -w -c "select count(*) from blocks;" &> /dev/null
+    psql -h "$DATABASE_HOST" -U "$DATABASE_USER" -d "$DATABASE_NAME" -w -c "select * from blocks limit 1;" &> /dev/null
     if [ $? == 1 ]; then
       download_blockchain
       restore_blockchain

--- a/scripts/start_lisk
+++ b/scripts/start_lisk
@@ -30,12 +30,10 @@ restore_blockchain() {
   then
     if [ -f blockchain.db ]; then
       psql -qd "$DATABASE_NAME" < blockchain.db &> /dev/null
-      psql -qd "$DATABASE_NAME" -c "CREATE DATABASE ${DATABASE_NAME}_check;" &> /dev/null
     fi
   else
     if [ -f blockchain.db ]; then
       psql -h "$DATABASE_HOST" -U "$DATABASE_USER" -d "$DATABASE_NAME" -w < blockchain.db &> /dev/null
-      psql -h "$DATABASE_HOST" -U "$DATABASE_USER" -d "$DATABASE_NAME" -w -c "CREATE DATABASE ${DATABASE_NAME}_check;" &> /dev/null
       rm $PGPASSFILE
     fi
   fi
@@ -55,22 +53,22 @@ populate_database() {
 
   if [ "$DATABASE_HOST" == "localhost" ]
   then
-    echo "Looking for database ${DATABASE_NAME}_check"
-    psql -ltAq | grep "^${DATABASE_NAME}_check|"
+    echo "Looking for peers table"
+    psql -qd "$DATABASE_NAME" -c "select count(*) from peers;" &> /dev/null
     if [ $? == 1 ]; then
       download_blockchain
       restore_blockchain
       else
-      echo "Found database ${DATABASE_NAME}_check"
+      echo "Found peers table"
     fi
   else
-    echo "Looking for database ${DATABASE_NAME}_check"
-    psql -h "$DATABASE_HOST" -U "$DATABASE_USER" -d "$DATABASE_NAME" -w -ltAq | grep "^${DATABASE_NAME}_check|"
+    echo "Looking for peers table"
+    psql -h "$DATABASE_HOST" -U "$DATABASE_USER" -d "$DATABASE_NAME" -w -c "select count(*) from peers;" &> /dev/null
     if [ $? == 1 ]; then
       download_blockchain
       restore_blockchain
       else
-      echo "Found database ${DATABASE_NAME}_check"
+      echo "Found peers table"
     fi
   fi
 }


### PR DESCRIPTION
Previously the containers would create a _check database to confirm that the snapshot restoration completed successfully. Now we check if the "peers" table exists and this should work just fine.

Fixes: https://github.com/LiskHQ/lisk-docker/issues/32