### PR TITLE
🐛 Fix new test config filenames

### DIFF
--- a/images/lisk-dev/Dockerfile
+++ b/images/lisk-dev/Dockerfile
@@ -16,8 +16,8 @@ RUN cd /home/lisk/lisk && \
     cp -f /home/lisk/lisk/test/data/config.json /home/lisk/config/ && \
     rm -f /home/lisk/lisk/config.json && \
     ln -s ../config/config.json /home/lisk/lisk/config.json && \
-    cp -f /home/lisk/lisk/test/data/genesisBlock.json \
-    /home/lisk/lisk/test/data/genesisDelegates.json /home/lisk/lisk/ && \
+    cp -f /home/lisk/lisk/test/data/genesis_block.json \
+    /home/lisk/lisk/test/data/genesis_delegates.json /home/lisk/lisk/ && \
     jq -c ".db.database = \"lisk_local\"" config.json |sponge config.json && \
     jq -c ".dapp.masterpassword = \"local\"" config.json |sponge config.json
 


### PR DESCRIPTION
I updated the Dockerfile to use the new `genesis_block.json` and `genesis_delegates.json`.

*Note:* The Jenkins build will still fail because of https://github.com/LiskHQ/lisk/issues/1568