### PR TITLE
Implement config using confd

### DIFF
--- a/examples/betanet/docker-compose.yml
+++ b/examples/betanet/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2"
 services:
 
   lisk:
-    image: lisk/betanet:next
+    image: lisk/betanet:1.0.0-beta.6
     volumes:
       - lisk-logs:/home/lisk/lisk/logs/
     ports:
@@ -14,7 +14,9 @@ services:
       - db
     command: ["/home/lisk/wait-for-it.sh", "db:5432", "--", "/home/lisk/run.sh"]
     environment:
-      - LISK_CONFIG_DB_DATABASE=lisk_beta
+      - LISK_DB_NAME=lisk_beta
+      - LISK_DB_HOST=db
+      - LISK_REDIS_HOST=redis
     restart: on-failure
 
   db:

--- a/images/Dockerfile.betanet
+++ b/images/Dockerfile.betanet
@@ -1,0 +1,36 @@
+FROM lisk/base
+
+ARG network=betanet
+ARG version
+ARG minVersion
+
+# download and verify image
+RUN curl --fail https://downloads.lisk.io/lisk/beta/lisk-Linux-x86_64.tar.gz --output betanet-lisk-Linux-x86_64.tar.gz && \
+    curl --fail https://downloads.lisk.io/lisk/beta/lisk-Linux-x86_64.tar.gz.SHA256 --output betanet-lisk-Linux-x86_64.tar.gz.SHA256 && \
+    sed -i 's/  \(lisk-Linux-x86_64.tar.gz\)/  betanet-\1/' betanet-lisk-Linux-x86_64.tar.gz.SHA256 && \
+    sha256sum -c betanet-lisk-Linux-x86_64.tar.gz.SHA256 && \
+    rm betanet-lisk-Linux-x86_64.tar.gz.SHA256
+
+# unpack the binaries
+RUN tar -xzf betanet-lisk-Linux-x86_64.tar.gz && \
+    rm betanet-lisk-Linux-x86_64.tar.gz && \
+    chown lisk:lisk --recursive /home/lisk/lisk-Linux-x86_64
+
+ENV VERSION ${version}
+ENV MIN_VERSION ${minVersion}
+
+# add seed nodes
+ENV LISK_PEERS_LIST_1 "94.237.41.99:5001"
+ENV LISK_PEERS_LIST_2 "209.50.52.217:5001"
+ENV LISK_PEERS_LIST_3 "94.237.26.150:5001"
+ENV LISK_PEERS_LIST_4 "83.136.249.102:5001"
+ENV LISK_PEERS_LIST_5 "94.237.65.179:5001"
+
+# set nethash
+ENV LISK_NETHASH "ef3844327d1fd0fc5785291806150c937797bdb34a748c9cd932b7e859e9ca0c"
+ENV LISK_WSPORT "5001"
+ENV LISK_HTTPPORT "5000"
+
+USER lisk
+WORKDIR /home/lisk/lisk-Linux-x86_64
+CMD ["/home/lisk/run.sh"]

--- a/images/Makefile
+++ b/images/Makefile
@@ -1,4 +1,10 @@
-all: testnet mainnet
+.PHONY: all clean testnet
+all: base betanet
 
-%:
-	make -C lisk $@
+tag = next
+
+base:
+	make -C lisk
+
+betanet:
+	docker build --build-arg network=betanet --tag lisk/betanet:$(version) --build-arg version="$(version)" --build-arg minVersion="$(minversion)" -f Dockerfile.betanet .

--- a/images/lisk/Dockerfile
+++ b/images/lisk/Dockerfile
@@ -1,22 +1,20 @@
 FROM ubuntu:16.04
 
-ARG network=testnet
-
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get --assume-yes install --no-install-recommends \
-        curl sudo unzip wget zip \
-        jq moreutils && \
+        curl wget sudo ca-certificates && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+RUN wget https://github.com/kelseyhightower/confd/releases/download/v0.15.0/confd-0.15.0-linux-amd64 && \
+    mv confd-0.15.0-linux-amd64 /usr/bin/confd && \
+    chmod +x /usr/bin/confd
 
 RUN groupadd --gid 1100 lisk && \
     useradd lisk --create-home --home-dir /home/lisk --shell /bin/bash --uid 1100 --gid 1100
 
-# the chown flag does not work with tarballs
-ADD ${network}-lisk-Linux-x86_64.tar.gz /home/lisk/
-RUN chown lisk:lisk --recursive /home/lisk/lisk-Linux-x86_64
 COPY --chown=lisk:lisk files/ /
+RUN chmod +x /home/lisk/wait-for-it.sh && \
+    chmod +x /home/lisk/run.sh
 
-USER lisk
-WORKDIR /home/lisk/lisk-Linux-x86_64
-CMD ["/home/lisk/run.sh"]
+WORKDIR /home/lisk

--- a/images/lisk/Makefile
+++ b/images/lisk/Makefile
@@ -1,43 +1,7 @@
 .PHONY: all clean testnet
-all: testnet mainnet
+all: base
 
-tag = next
+tag = latest
 
-clean:
-	rm -f *-lisk-Linux-x86_64.tar.gz*
-
-betanet-lisk-Linux-x86_64.tar.gz:
-	curl --fail https://downloads.lisk.io/lisk/beta/lisk-Linux-x86_64.tar.gz --output betanet-lisk-Linux-x86_64.tar.gz
-	curl --fail https://downloads.lisk.io/lisk/beta/lisk-Linux-x86_64.tar.gz.SHA256 --output betanet-lisk-Linux-x86_64.tar.gz.SHA256
-	sed -i 's/  \(lisk-Linux-x86_64.tar.gz\)/  betanet-\1/' betanet-lisk-Linux-x86_64.tar.gz.SHA256
-	sha256sum -c betanet-lisk-Linux-x86_64.tar.gz.SHA256
-
-betanet: betanet-lisk-Linux-x86_64.tar.gz
-	docker build --build-arg network=betanet --tag lisk/betanet:$(tag) .
-
-development-lisk-Linux-x86_64.tar.gz:
-	curl --fail https://downloads.lisk.io/lisk/development/lisk-Linux-x86_64.tar.gz --output development-lisk-Linux-x86_64.tar.gz
-	curl --fail https://downloads.lisk.io/lisk/development/lisk-Linux-x86_64.tar.gz.SHA256 --output development-lisk-Linux-x86_64.tar.gz.SHA256
-	sed -i 's/  \(lisk-Linux-x86_64.tar.gz\)/  development-\1/' development-lisk-Linux-x86_64.tar.gz.SHA256
-	sha256sum -c development-lisk-Linux-x86_64.tar.gz.SHA256
-
-development: development-lisk-Linux-x86_64.tar.gz
-	docker build --build-arg network=development --tag lisk/development:$(tag) .
-
-mainnet-lisk-Linux-x86_64.tar.gz:
-	curl --fail https://downloads.lisk.io/lisk/main/lisk-Linux-x86_64.tar.gz --output mainnet-lisk-Linux-x86_64.tar.gz
-	curl --fail https://downloads.lisk.io/lisk/main/lisk-Linux-x86_64.tar.gz.SHA256 --output mainnet-lisk-Linux-x86_64.tar.gz.SHA256
-	sed -i 's/  \(lisk-Linux-x86_64.tar.gz\)/  mainnet-\1/' mainnet-lisk-Linux-x86_64.tar.gz.SHA256
-	sha256sum -c mainnet-lisk-Linux-x86_64.tar.gz.SHA256
-
-mainnet: mainnet-lisk-Linux-x86_64.tar.gz
-	docker build --build-arg network=mainnet --tag lisk/mainnet:$(tag) .
-
-testnet-lisk-Linux-x86_64.tar.gz:
-	curl --fail https://downloads.lisk.io/lisk/test/lisk-Linux-x86_64.tar.gz --output testnet-lisk-Linux-x86_64.tar.gz
-	curl --fail https://downloads.lisk.io/lisk/test/lisk-Linux-x86_64.tar.gz.SHA256 --output testnet-lisk-Linux-x86_64.tar.gz.SHA256
-	sed -i 's/  \(lisk-Linux-x86_64.tar.gz\)/  testnet-\1/' testnet-lisk-Linux-x86_64.tar.gz.SHA256
-	sha256sum -c testnet-lisk-Linux-x86_64.tar.gz.SHA256
-
-testnet: testnet-lisk-Linux-x86_64.tar.gz
-	docker build --tag lisk/testnet:$(tag) .
+base:
+	docker build --build-arg network=betanet --tag lisk/base:$(tag) .

--- a/images/lisk/files/etc/confd/conf.d/lisk.toml
+++ b/images/lisk/files/etc/confd/conf.d/lisk.toml
@@ -1,0 +1,6 @@
+[template]
+src = "config.json.tmpl"
+dest = "/home/lisk/lisk-Linux-x86_64/config.json"
+keys = [
+    "/lisk",
+]

--- a/images/lisk/files/etc/confd/templates/config.json.tmpl
+++ b/images/lisk/files/etc/confd/templates/config.json.tmpl
@@ -1,0 +1,104 @@
+{
+	"wsPort": {{getv "/lisk/wsport" "5001"}},
+	"httpPort": {{getv "/lisk/httpport" "5000"}},
+	"address": "0.0.0.0",
+	"version": "{{getenv "VERSION"}}",
+	"minVersion": "{{getenv "MIN_VERSION"}}",
+	"fileLogLevel": "{{getv "/lisk/log/filelevel" "info"}}",
+	"logFileName": "{{getv "/lisk/log/filepath" "logs/lisk.log"}}",
+	"consoleLogLevel": "{{getv "/lisk/log/consolelevel" "none"}}",
+	"trustProxy": {{getv "/lisk/trustproxy" "false"}},
+	"topAccounts": {{getv "/lisk/topaccounts" "false"}},
+	"cacheEnabled": {{getv "/lisk/cacheenabled" "false"}},
+	"wsWorkers": {{getv "/lisk/wsworkers" "1"}},
+	"db": {
+		"host": "{{getv "/lisk/db/host" "db"}}",
+		"port": {{getv "/lisk/db/port" "5432"}},
+		"database": "{{getv "/lisk/db/name" "lisk"}}",
+		"user": "{{getv "/lisk/db/user" "lisk"}}",
+		"password": "{{getv "/lisk/db/password" "password"}}",
+		"min": {{getv "/lisk/db/min" "10"}},
+		"max": {{getv "/lisk/db/max" "95"}},
+		"poolIdleTimeout": {{getv "/lisk/db/poolidletimeout" "30000"}},
+		"reapIntervalMillis": {{getv "/lisk/db/reapintervalms" "1000"}},
+		"logEvents": ["error"],
+		"logFileName": "{{getv "/lisk/db/logpath" "logs/lisk_db.log"}}"
+	},
+	"redis": {
+		"host": "{{getv "/lisk/redis/host" "redis"}}",
+		"port": {{getv "/lisk/redis/port" "6380"}},
+		"db": {{getv "/lisk/redis/db" "0"}},
+		"password": {{getv "/lisk/redis/password" "null"}}
+	},
+	"api": {
+		"enabled": {{getv "/lisk/api/enabled" "true"}},
+		"access": {
+			"public": {{getv "/lisk/api/public" "false"}},
+			{{$whiteListEntries := getvs "/lisk/api/whitelist/*"}}"whiteList": [{{range $index, $element := $whiteListEntries}}{{if $index}},{{end}}"{{$element}}"{{end}}]
+		},
+		"options": {
+			"limits": {
+				"max": {{getv "/lisk/api/limits/max" "0"}},
+				"delayMs": {{getv "/lisk/api/limits/delayms" "0"}},
+				"delayAfter": {{getv "/lisk/api/limits/delayafter" "0"}},
+				"windowMs": {{getv "/lisk/api/limits/windowms" "60000"}}
+			}
+		}
+	},
+	"peers": {
+		"enabled": {{getv "/lisk/peers/enabled" "true"}},
+		"list": [{{range $index, $element := (getvs "/lisk/peers/list/*")}}{{$data := split $element ":"}}{{if $index}},{{end}}
+			{
+  				"ip": "{{index $data 0}}",
+  				"wsPort": {{index $data 1}}
+			}{{end}}
+		],
+		"access": {
+			{{$blackListEntries := getvs "/lisk/peers/blacklist/*"}}"blackList": [{{range $index, $element := $blackListEntries}}{{if $index}},{{end}}"{{$element}}"{{end}}]
+		},
+		"options": {
+			"timeout": {{getv "/lisk/peer/timeout" "5000"}}
+		}
+	},
+	"broadcasts": {
+		"active": {{getv "/lisk/broadcasts/active" "true"}},
+		"broadcastInterval": {{getv "/lisk/broadcasts/interval" "5000"}},
+		"broadcastLimit": {{getv "/lisk/broadcasts/limit/broadcast" "20"}},
+		"parallelLimit": {{getv "/lisk/broadcasts/limit/parallel" "20"}},
+		"releaseLimit": {{getv "/lisk/broadcasts/limit/release" "25"}},
+		"relayLimit": {{getv "/lisk/broadcasts/limit/relay" "2"}}
+	},
+	"transactions": {
+		"maxTransactionsPerQueue": {{getv "/lisk/transactions/maxperqueue" "1000"}}
+	},
+	"forging": {
+		"force": {{getv "/lisk/forging/force" "false"}},
+		"defaultKey": "{{getv "/lisk/forging/defaultkey" ""}}",
+		"secret": [{{range $index, $element := (getvs "/lisk/forging/secret/*")}}{{$data := split $element ":"}}{{if $index}},{{end}}
+            {
+                "encryptedSecret": "{{index $data 0}}",
+                "publicKey": "{{index $data 1}}"
+            }{{end}}
+        ],
+		"access": {
+			{{$whiteListEntries := getvs "/lisk/forging/whitelist/*"}}"whiteList": [{{range $index, $element := $whiteListEntries}}{{if $index}},{{end}}"{{$element}}"{{end}}]
+		}
+	},
+	"syncing": {
+		"active": {{getv "/lisk/syncing/active" "true"}}
+	},
+	"loading": {
+		"verifyOnLoading": {{getv "/lisk/loading/verify" "false"}},
+		"loadPerIteration": {{getv "/lisk/loading/loadperiteration" "5000"}}
+	},
+	"ssl": {
+		"enabled": {{getv "/lisk/ssl/enabled" "false"}},
+		"options": {
+			"port":{{getv "/lisk/ssl/port" "443"}},
+			"address": "0.0.0.0",
+			"key": "{{getv "/lisk/ssl/key" "./ssl/lisk.key"}}",
+			"cert": "{{getv "/lisk/ssl/cert" "./ssl/lisk.crt"}}"
+		}
+	},
+	"nethash": "{{getv "/lisk/nethash" "ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511"}}"
+}

--- a/images/lisk/files/home/lisk/run.sh
+++ b/images/lisk/files/home/lisk/run.sh
@@ -1,23 +1,9 @@
 #!/bin/bash
 
-function jq_config {
-	jq -c "$1" config.json |sponge config.json
-}
+# generate config
+confd -onetime -backend env
 
-jq_config ".api.access.public = true"
-
-jq_config ".consoleLogLevel = \"${LISK_CONFIG_CONSOLE_LOG_LEVEL:=info}\""
-
-if [ "${LISK_CONFIG_FORGING_WHITELIST_IP:=127.0.0.1}" != "127.0.0.1" ]
-then
-	jq_config ".forging.access.whiteList = [\"127.0.0.1\",\"$LISK_CONFIG_FORGING_WHITELIST_IP\"]"
-fi
-jq_config ".db.host = \"${LISK_CONFIG_DB_HOST:=db}\""
-jq_config ".db.port = ${LISK_CONFIG_DB_PORT:=5432}"
-jq_config ".db.database = \"${LISK_CONFIG_DB_DATABASE:=lisk_test}\""
-jq_config ".db.user = \"${LISK_CONFIG_DB_USER:=lisk}\""
-jq_config ".db.password = \"${LISK_CONFIG_DATABASE_PASSWORD:=password}\""
-
+# launch Lisk Core
 export PATH=/home/lisk/lisk-Linux-x86_64/bin:$PATH
 export LD_LIBRARY_PATH=/home/lisk/lisk-Linux-x86_64/pgsql/lib
 node app.js


### PR DESCRIPTION
I don't actually want this to be merged like this. This only includes files for betanet builds.

## What I changed
* I moved the package download to the Docker build process to builds will be more platform independent and can also be automatically built on DockerHub for increased trust (would be even better if built from source)
* I added confd for configuration management, which allows every config parameter to be tweaked either using environment variables or via a configuration management tool like etcd, consul.

This will finally allow users to run a forging node using Docker as well as fully customize the Core node.

## Examples for usage

`LISK_FORGING_SECRET_1 = encryptedSecret:publicKey`
`LISK_API_WHITELIST_1 = 127.0.0.1`
`LISK_API_WHITELIST_2 = 5.1.5.7`
`LISK_API_ENABLED = true`
`LISK_API_PUBLIC = false`

Every parameter with a number suffix can be used to create an unlimited amount of entries for that parameter, like API whitelist, blacklist and encrypted forging secrets as well as seed nodes.

This is just a small subset of the possible environment variables. Every single config parameter can be modified using environment variables with this setup. Please consult `config.json.tmpl` for all possible variables.

## Proposal
Please add confd and config templates to the default Lisk image. You can feel free to use the config template from my pull request as well as the related scripts.

Configuration via environment variables or other services supported by confd are the de facto industry standard and will allow large scale deployments of Lisk core nodes on Docker e.g. with Kubernetes.

Having to bake a `config.json` into the image as proposed in #75 should never be done and could lead to people leaking secrets + it's harder to deploy.